### PR TITLE
Python 3 support and Unicode character support for Python 2

### DIFF
--- a/sample/sample1.py
+++ b/sample/sample1.py
@@ -68,7 +68,7 @@ try:
 		status = rrow.get_field_as_bool(1)
 		count = rrow.get_field_as_long(2) + 1
 		lob = rrow.get_field_as_blob(3)
-		print "Person: name={0} status={1} count={2} lob=[{3}]".format(name, status, count, ', '.join(str(e) for e in lob))
+		print("Person: name={0} status={1} count={2} lob=[{3}]".format(name, status, count, ', '.join(str(e) for e in lob)))
 		
 		#Update row
 		rrow.set_field_by_long(2, count)
@@ -77,4 +77,4 @@ try:
 	#End transaction
 	col.commit()
 except griddb.GSException as e:
-	print e.what()
+	print(e.what())

--- a/sample/sample2.py
+++ b/sample/sample2.py
@@ -47,7 +47,7 @@ try:
 		timestamp = rrow.get_field_as_timestamp(0)
 		active = rrow.get_field_as_bool(1)
 		voltage = rrow.get_field_as_double(2)
-		print "Time={0} Active={1} Voltage={2}".format(timestamp, active, voltage)
+		print("Time={0} Active={1} Voltage={2}".format(timestamp, active, voltage))
 
 except griddb.GSException as e:
-		print e.what()
+		print(e.what())

--- a/sample/sample3.py
+++ b/sample/sample3.py
@@ -44,7 +44,7 @@ try:
 			#Get aggregation result
 			aggResult = aggRs.get_next_aggregation()
 			#Convert result to double and print out
-			print "[Timestamp={0}] Average voltage = {1}".format(timestamp, aggResult.get_double())
+			print("[Timestamp={0}] Average voltage = {1}".format(timestamp, aggResult.get_double()))
 	
 except griddb.GSException as e:
-	print e.what()
+	print(e.what())

--- a/src/griddb.i
+++ b/src/griddb.i
@@ -16,8 +16,6 @@
 
 %include "gstype.i"
 
-%include <std_except.i>
-
 #if defined(SWIGPYTHON)
 %include "gstype_python.i"
 %module griddb_python_client
@@ -40,10 +38,6 @@
 #include "StoreFactory.h"
 #include "Timestamp.h"
 %}
-
-%include <std_shared_ptr.i>
-%include <typemaps.i>
-%catches(griddb::GSException);
 
 %shared_ptr(griddb::Resource)
 %shared_ptr(griddb::AggregationResult)

--- a/src/gstype.i
+++ b/src/gstype.i
@@ -14,10 +14,23 @@
    limitations under the License.
 */
 
+#if defined(SWIGPYTHON)
+%module griddb_python_client
+%begin %{
+#define SWIG_PYTHON_2_UNICODE
+%}
+#elif defined(SWIGRUBY)
+%module griddb_ruby_client
+#endif
+
 %include <stdint.i>
 %include <std_string.i>
 %include <std_map.i>
-%include "std_vector.i"
+%include <std_except.i>
+%include <std_shared_ptr.i>
+
+%include <typemaps.i>
+%catches(griddb::GSException);
 
 enum GSContainerTypeTag {
     GS_CONTAINER_COLLECTION,

--- a/src/gstype_python.i
+++ b/src/gstype_python.i
@@ -14,16 +14,23 @@
    limitations under the License.
 */
 
-%typemap(in) (const GSColumnInfo* props, int propsCount) (PyObject* tuple, int i) {
+/**
+* Typemaps for put_container() function
+*/
+%typemap(in, fragment = "SWIG_AsCharPtrAndSize") (const GSColumnInfo* props, int propsCount)
+(PyObject* tuple, int i, size_t size = 0, int* alloc = 0, int res, char* v = 0, int val) {
 //Convert Python list of tuple into GSColumnInfo properties
     if (!PyList_Check($input)) {
         PyErr_SetString(PyExc_ValueError,"Expected a List");
         return NULL;
     }
-    $2 = (int)PyInt_AS_LONG(PyInt_FromSsize_t(PyList_Size($input)));
+    $2 = (int)PyInt_AsLong(PyLong_FromSsize_t(PyList_Size($input)));
     $1 = NULL;
     if ($2 > 0) {
         $1 = (GSColumnInfo *) malloc($2*sizeof(GSColumnInfo));
+        alloc = (int*) malloc($2*sizeof(int));
+        memset(alloc, 0x0, $2*sizeof(int));
+
         i = 0;
         while (i < $2) {
             tuple = PyList_GetItem($input,i);
@@ -32,8 +39,18 @@
                 free((void *) $1);
                 return NULL;
             }
-            $1[i].name = PyString_AS_STRING(PyTuple_GetItem(tuple,0)); 
-            $1[i].type = (int)(PyInt_AS_LONG(PyTuple_GetItem(tuple,1)));
+            res = SWIG_AsCharPtrAndSize(PyTuple_GetItem(tuple,0), &v, &size, &alloc[i]);
+            if (!SWIG_IsOK(res)) {
+                %variable_fail(res, "String", "name");
+            }
+
+            if(!PyInt_Check(PyTuple_GetItem(tuple,1))) {
+                PyErr_SetString(PyExc_ValueError,"Expected an Integer as column type");
+                return NULL;
+            }
+
+            $1[i].name = v;
+            $1[i].type = (int)(PyInt_AsLong(PyTuple_GetItem(tuple,1)));
             i++;
         }
     }
@@ -43,31 +60,63 @@
    $1 = PyList_Check($input) ? 1 : 0;
 }
 
-%typemap(freearg) (const GSColumnInfo* props, int propsCount) {
-  free((void *) $1);
+%typemap(freearg) (const GSColumnInfo* props, int propsCount) (int i) {
+  if ($1) {
+	for (i = 0; i < $2; i++) {
+	  if (alloc$argnum[i] == SWIG_NEWOBJ) {
+		%delete_array($1[i].name);
+	  }
+    }
+    free((void *) $1);
+  }
 }
 
-%typemap(in) (const GSPropertyEntry* props, int propsCount) (int i, Py_ssize_t si, PyObject* key, PyObject* val) {
+%typemap(in, fragment = "SWIG_AsCharPtrAndSize") (const GSPropertyEntry* props, int propsCount)
+(int i, int j, Py_ssize_t si, PyObject* key, PyObject* val, size_t size = 0, int* alloc = 0, int res, char* v = 0) {
     if (!PyDict_Check($input)) {
         PyErr_SetString(PyExc_ValueError,"Expected a Dict");
         return NULL;
     }
-    $2 = (int)PyInt_AS_LONG(PyInt_FromSsize_t(PyDict_Size($input)));
+    $2 = (int)PyInt_AsLong(PyLong_FromSsize_t(PyDict_Size($input)));
     $1 = NULL;
     if ($2 > 0) {
         $1 = (GSPropertyEntry *) malloc($2*sizeof(GSPropertyEntry));
+        alloc = (int*) malloc($2 * 2 * sizeof(int));
+        memset(alloc, 0, $2 * 2 * sizeof(int));
         i = 0;
+        j = 0;
         si = 0;
         while (PyDict_Next($input, &si, &key, &val)) {
-            $1[i].name = PyString_AS_STRING(key);
-            $1[i].value = PyString_AS_STRING(val);
+            res = SWIG_AsCharPtrAndSize(key, &v, &size, &alloc[j]);
+            if (!SWIG_IsOK(res)) {
+                %variable_fail(res, "String", "name");
+            }
+
+            $1[i].name = v;
+            res = SWIG_AsCharPtrAndSize(val, &v, &size, &alloc[j + 1]);
+            if (!SWIG_IsOK(res)) {
+                %variable_fail(res, "String", "value");
+            }
+            $1[i].value = v;
             i++;
+            j+=2;
         }
     }
 }
 
-%typemap(freearg) (const GSPropertyEntry* props, int propsCount) {
-  free((void *) $1);
+%typemap(freearg) (const GSPropertyEntry* props, int propsCount) (int i = 0, int j = 0) {
+  if ($1) {
+    for (i = 0; i < $2; i++) {
+      if (alloc$argnum[j] == SWIG_NEWOBJ) {
+        %delete_array($1[i].name);
+      }
+      if (alloc$argnum[j + 1] == SWIG_NEWOBJ) {
+        %delete_array($1[i].value);
+      }
+      j += 2;
+    }
+    free((void *) $1);
+  }
 }
 
 %typemap(in) (GSQuery* const* queryList, size_t queryCount) (PyObject* pyQuery, std::shared_ptr<griddb::Query> query, void *vquery, int i, int res = 0) {
@@ -75,7 +124,7 @@
         PyErr_SetString(PyExc_ValueError,"Expected a List");
         return NULL;
     }
-    $2 = (size_t)PyInt_AS_LONG(PyInt_FromSsize_t(PyList_Size($input)));
+    $2 = (size_t)PyInt_AsLong(PyLong_FromSsize_t(PyList_Size($input)));
     $1 = NULL;
     i = 0;
     if($2 > 0) {
@@ -103,22 +152,32 @@
 }
 
 %typemap(freearg) (GSQuery* const* queryList, size_t queryCount) {
-  free((void *) $1);
+  if ($1) {
+    free((void *) $1);
+  }
 }
 
-%typemap(in) (const GSContainerRowEntry* entryList, size_t entryCount) (int i, int j, int res = 0, void** pRowList = 0, Py_ssize_t listSize, Py_ssize_t dictSize, PyObject* key, PyObject* val, PyObject* pyRow, void* vrow, std::shared_ptr<griddb::Row> row, std::shared_ptr<griddb::Row>* sprow, griddb::Row* prow) {
+%typemap(in, fragment = "SWIG_AsCharPtrAndSize") (const GSContainerRowEntry* entryList, size_t entryCount)
+(int i, int j, int res = 0, void** pRowList = 0, Py_ssize_t listSize, Py_ssize_t dictSize, PyObject* key, PyObject* val, PyObject* pyRow, void* vrow, std::shared_ptr<griddb::Row> row, std::shared_ptr<griddb::Row>* sprow, griddb::Row* prow, size_t size = 0, int* alloc = 0, char* v = 0) {
     if (!PyDict_Check($input)) {
         PyErr_SetString(PyExc_ValueError,"Expected a Dict");
         return NULL;
     }
-    $2 = (int)PyInt_AS_LONG(PyInt_FromSsize_t(PyDict_Size($input)));
+    $2 = (int)PyInt_AsLong(PyLong_FromSsize_t(PyDict_Size($input)));
     $1 = NULL;
     if ($2 > 0) {
         $1 = (GSContainerRowEntry *) malloc($2*sizeof(GSContainerRowEntry));
+        alloc = (int*) malloc($2*sizeof(int));
+        memset($1, 0x0, $2*sizeof(GSContainerRowEntry));
+        memset(alloc, 0x0, $2*sizeof(int));
         i = 0;
         dictSize = 0;
         while (PyDict_Next($input, &dictSize, &key, &val)) {
-            $1[i].containerName = PyString_AS_STRING(key);
+            res = SWIG_AsCharPtrAndSize(key, &v, &size, &alloc[i]);
+            if (!SWIG_IsOK(res)) {
+                %variable_fail(res, "String", "containerName");
+            }
+            $1[i].containerName = v;
             if (!PyList_Check(val)) {
                 PyErr_SetString(PyExc_ValueError,"Expected a List as Dict element");
                 free((void *) $1);
@@ -126,7 +185,7 @@
             }
 
             // Get Row element from list
-            listSize = (int)PyInt_AS_LONG(PyInt_FromSsize_t(PyList_Size(val)));
+            listSize = (int)PyInt_AsLong(PyLong_FromSsize_t(PyList_Size(val)));
             if (listSize > 0) {
                 pRowList = (void**)malloc(listSize*sizeof(void *));
                 $1[i].rowList = pRowList;
@@ -161,13 +220,19 @@
 }
 
 %typemap(freearg) (const GSContainerRowEntry* entryList, size_t entryCount) (int i) {
-    for (i = 0; i < $2; i++) {
-        if ($1[i].rowList) {
-            free((void *) $1[i].rowList);
-        }
-    }
-    
+  if ($1) {
+	for (i = 0; i < $2; i++) {
+	  if ($1[i].rowList) {
+		free((void *) $1[i].rowList);
+	  }
+
+	  if (alloc$argnum[i] == SWIG_NEWOBJ) {
+		%delete_array($1[i].containerName);
+	  }
+	}
+
     free((void *) $1);
+  }
 }
 
 %typemap(in) (const void* const * rowObjs, size_t rowCount) (PyObject* pyRow, std::shared_ptr<griddb::Row> row, void *vrow, int i, int res = 0) {
@@ -175,7 +240,7 @@
         PyErr_SetString(PyExc_ValueError,"Expected a List");
         return NULL;
     }
-    $2 = (size_t)PyInt_AS_LONG(PyInt_FromSsize_t(PyList_Size($input)));
+    $2 = (size_t)PyInt_AsLong(PyLong_FromSsize_t(PyList_Size($input)));
     $1 = NULL;
     i = 0;
     if($2 > 0) {
@@ -203,7 +268,9 @@
 }
 
 %typemap(freearg) (const void* const * rowObjs, size_t rowCount) {
-  free((void *) $1);
+  if ($1) {
+    free((void *) $1);
+  }
 }
 
 %typemap(in) (const int8_t *fieldValue, size_t size) (int i) {
@@ -211,13 +278,13 @@
         PyErr_SetString(PyExc_ValueError,"Expected a List");
         return NULL;
     }
-    $2 = (int)PyInt_AS_LONG(PyInt_FromSsize_t(PyList_Size($input)));
+    $2 = (int)PyInt_AsLong(PyLong_FromSsize_t(PyList_Size($input)));
     $1 = NULL;
     if ($2 > 0) {
         $1 = (int8_t *) malloc($2*sizeof(int8_t));
         i = 0;
         while(i < $2) {
-        	$1[i] = (int8_t)PyInt_AS_LONG(PyList_GetItem($input,i));
+        	$1[i] = (int8_t)PyInt_AsLong(PyList_GetItem($input,i));
         	i++;
 
         }
@@ -225,25 +292,33 @@
 }
 
 %typemap(freearg) (const int8_t *fieldValue, size_t size) {
-  free((void *) $1);
+  if ($1) {
+    free((void *) $1);
+  }
 }
 
-%typemap(in) (const GSRowKeyPredicateEntry *const * predicateList, size_t predicateCount) (PyObject* key, PyObject* val, std::shared_ptr<griddb::RowKeyPredicate> pPredicate, GSRowKeyPredicateEntry* pList, void *vpredicate, Py_ssize_t si, int i, int res = 0) {
+%typemap(in, fragment = "SWIG_AsCharPtrAndSize") (const GSRowKeyPredicateEntry *const * predicateList, size_t predicateCount) (PyObject* key, PyObject* val, std::shared_ptr<griddb::RowKeyPredicate> pPredicate, GSRowKeyPredicateEntry* pList, void *vpredicate, Py_ssize_t si, int i, int res = 0, size_t size = 0, int* alloc = 0, char* v = 0) {
     if(!PyDict_Check($input)) {
         PyErr_SetString(PyExc_ValueError,"Expected a Dict");
         return NULL;
     }
-    $2 = (size_t)PyInt_AS_LONG(PyInt_FromSsize_t(PyDict_Size($input)));
+    $2 = (size_t)PyInt_AsLong(PyLong_FromSsize_t(PyDict_Size($input)));
     $1 = NULL;
     i = 0;
     si = 0;
     if($2 > 0) {
         pList = (GSRowKeyPredicateEntry*) malloc($2*sizeof(GSRowKeyPredicateEntry));
+        alloc = (int*) malloc($2 * sizeof(int));
+        memset(alloc, 0x0, $2*sizeof(int));
         $1 = &pList;
  
         while (PyDict_Next($input, &si, &key, &val)) {
             GSRowKeyPredicateEntry *predicateEntry = &pList[i];
-            predicateEntry->containerName = PyString_AS_STRING(key);
+            res = SWIG_AsCharPtrAndSize(key, &v, &size, &alloc[i]);
+            if (!SWIG_IsOK(res)) {
+                %variable_fail(res, "String", "containerName");
+            }
+            predicateEntry->containerName = v;
             //Get GSRowKeyPredicate pointer from RowKeyPredicate pyObject
             int newmem = 0;
             res = SWIG_ConvertPtrAndOwn(val, (void **) &vpredicate, $descriptor(std::shared_ptr<griddb::RowKeyPredicate>*), %convertptr_flags, &newmem);
@@ -263,9 +338,15 @@
     }
 }
 
-%typemap(freearg) (const GSRowKeyPredicateEntry *const * predicateList, size_t predicateCount) (int i) {
+%typemap(freearg) (const GSRowKeyPredicateEntry *const * predicateList, size_t predicateCount) (int i, GSRowKeyPredicateEntry* pList) {
     if ($1 && *$1) {
-        free((void *) *$1);
+        pList = *$1;
+        for (i = 0; i < $2; i++) {
+            if (alloc$argnum[i] == SWIG_NEWOBJ) {
+                %delete_array(pList[i].containerName);
+            }
+        }
+        free((void *) pList);
     }
 }
 
@@ -355,7 +436,9 @@
 }
 
 %typemap(freearg) (const GSBlob *fieldValue) {
-    free((void *) $1);
+    if ($1) {
+        free((void *) $1);
+    }
 }
 
 %typemap(in, numinputs = 0) (GSBlob *value) (GSBlob pValue) {


### PR DESCRIPTION
I updated typemaps files so that the source code could be built and run with Python 3.
The main updates are for int type and string type handling.
In Python 3, PyInt is removed so functions related to PyInt are changed to PyLong instead.
I change from using PyString_AS_STRING to SWIG_AsCharPtrAndSize to check and handle correctly for each string type (PyUnicode, PyBytes, PyString).
By default, a Unicode string will fail to convert to C/C++ string in Python 2 so to make its behavior similar to Python 3, I define Unicode encode for Python 2 in typemaps (gstype.i).